### PR TITLE
fix: update Trivy image tag to resolve Docker pull error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v ${{ github.workspace }}:/src \
-            aquasec/trivy:latest image \
+            aquasec/trivy:canary image \
             --format json \
             --output trivy-custom-image-results.json \
             --platform linux/amd64 \


### PR DESCRIPTION
- Change aquasec/trivy:latest to aquasec/trivy:canary
- Fix 'manifest unknown' error in CI/CD pipeline
- Ensure security scanning continues to work properly